### PR TITLE
Handled noComment error in summary of responses

### DIFF
--- a/components/questions.js
+++ b/components/questions.js
@@ -71,14 +71,9 @@ export default function Questions(props) {
   function handleDone() {
     if (confidence === DEFAULT_CONFIDENCE) {
       setError("noConfidence");
-      console.log("Set error");
     }
-    // if it is the last question and the user hasn't typed at least one comment then set error when the user clicks next button
-    else if (
-      props.counter == props.total &&
-      props.count == 0 &&
-      comment.length < MIN_LENGTH
-    ) {
+    // if the user hasn't typed at least one comment then set error when the user clicks done button
+    else if (props.count(props.counter - 1) == 0 && comment.length < MIN_LENGTH) {
       setError("noComment");
     } else {
       let res = {answer: answer, comment: comment, confidence: confidence};
@@ -184,7 +179,7 @@ export default function Questions(props) {
         />
       </Form.Group>
 
-      <div className={error == "noComment" ? "alert-danger p-1" : "d-none"}>
+      <div className={error == "noComment" ? "alert-danger p-1 mb-3" : "d-none"}>
         At least one meaningful comment is required
       </div>
 

--- a/components/summary.js
+++ b/components/summary.js
@@ -16,19 +16,6 @@ export default function Summary(props) {
     setModify(false);
   }
 
-  function countComment() {
-    // function to get number of meaningful comments other than the current question
-    var countValue = 0;
-    var i = 0;
-    Object.values(props.allResults).map((ans) => {
-      if (i != props.index && ans.comment.length >= MIN_LENGTH) {
-        number++;
-      }
-      i++;
-    });
-    return countValue;
-  }
-
   return (
     <div className="mt-3 mb-3 pl-4 pr-4">
       {!modify && (

--- a/components/summary.js
+++ b/components/summary.js
@@ -16,6 +16,19 @@ export default function Summary(props) {
     setModify(false);
   }
 
+  function countComment() {
+    // function to get number of meaningful comments other than the current question
+    var countValue = 0;
+    var i = 0;
+    Object.values(props.allResults).map((ans) => {
+      if (i != props.index && ans.comment.length >= MIN_LENGTH) {
+        number++;
+      }
+      i++;
+    });
+    return countValue;
+  }
+
   return (
     <div className="mt-3 mb-3 pl-4 pr-4">
       {!modify && (
@@ -79,6 +92,7 @@ export default function Summary(props) {
             onModify={handleModification}
             mode={true}
             result={result}
+            count={props.count}
           />
         </>
       )}

--- a/pages/review.js
+++ b/pages/review.js
@@ -192,13 +192,15 @@ export default function Review(props) {
   const [result, setResult] = useState({});
   const [summaryMode, setSummaryMode] = useState(true);
 
-  function countComment() {
+  function countComment(index) {
     // function to get number of meaningful comments
     var number = 0;
+    var i = 0;
     Object.values(result).map((ans) => {
-      if (ans.comment.length >= MIN_LENGTH) {
+      if (i != index && ans.comment.length >= MIN_LENGTH) {
         number++;
       }
+      i++;
     });
     return number;
   }
@@ -433,6 +435,8 @@ export default function Review(props) {
                 total={questions.length}
                 onSummaryModify={handleSummary}
                 result={result[questions[index].item]}
+                allResults={result}
+                count={countComment}
               />
             ))}
             <div className="text-center pb-3">


### PR DESCRIPTION
Currently, if a reviewer deletes or modifies their comment in the summary section then no error is displayed. In this PR I have added error handling to the summary section as well. The `countComment()` function has been modified for this purpose. It now counts the number of meaningful comments in all questions except the currently selected one in the summary section. If the returned value is zero and the length of the comment in the current question is less than MIN_VALUE, an error is displayed on clicking `Done`.